### PR TITLE
7.2.2020 history moved from redux slice to react component

### DIFF
--- a/src/_THINGS TO DO
+++ b/src/_THINGS TO DO
@@ -4,8 +4,7 @@ Major Updates:
     2) Actual changes to data based upon selection (updating .json files via redux actions)
         - or connecting to a database
 
-Known Issues:
-    - D lost to C and still has a higher rank (trying to go alphabetical)
+Known Issues
     - F facing against A twice at the end. 
     - F facing D skipping vs C
     - E Facing A and B again (gives wins to everything prior to E appearing then if E wins or losses first fight and the opposite on the subsequent it'll reface its first opponent)

--- a/src/app/slices/movielistSlice.js
+++ b/src/app/slices/movielistSlice.js
@@ -128,13 +128,11 @@ const movielistSlice = createSlice({
             (movies) => movies.rank === OptionB.rank
           );
           OptionA.active = "lost";
-          OptionA.history.push(OptionB.id);
+
           if (OptionA.history.includes(OptionB.id)) {
             console.log(console.log("EXIT THE LOOP WE GOT HIM"));
             delete OptionA.active;
-          }
-          // LOSING TO TOP RANKED ITEM
-          else if (index === 0) {
+          } else if (index === 0) {
             delete OptionA.active;
             console.log("index 0 event loss occured - lost to top dawg");
           } else if (index === rankedMovies.length - 1) {
@@ -144,6 +142,7 @@ const movielistSlice = createSlice({
             const lostNewRank =
               (rankedMovies[index].rank + rankedMovies[index + 1].rank) / 2;
             OptionA.rank = lostNewRank;
+            OptionA.history.push(OptionB.id);
 
             console.log("Option B Selected - Incumbent");
           }

--- a/src/app/slices/movielistSlice.js
+++ b/src/app/slices/movielistSlice.js
@@ -98,33 +98,39 @@ const movielistSlice = createSlice({
           const index = rankedMovies.findIndex(
             (movies) => movies.rank === OptionB.rank
           );
-          if (OptionA.history.includes(OptionB.id) === true) {
-            console.log("EXIT THE LOOP WE GOT HIM");
+          console.log("RANKED VS RANKED: A SELECTED -->");
+          console.log(rankedMovies);
+          OptionA.active = "won";
+
+          if (rankedMovies[0].rank === OptionA.rank) {
+            console.log("WE SHOULD KICK THIS OUT OF THE LOOP - redux slice");
             delete OptionA.active;
-          }
-          OptionA.history.push(OptionB.id);
-          console.log("newish index: " + index);
-          if (index === 0) {
+          } else if (index === 0) {
             const newTopRank = rankedMovies[index].rank / 2;
             OptionA.rank = newTopRank;
+            delete OptionA.active;
+          } else if (OptionA.history.includes(OptionB.id) === true) {
+            console.log("EXIT THE LOOP WE GOT HIM");
             delete OptionA.active;
           } else {
             const newRank =
               (rankedMovies[index - 1].rank + rankedMovies[index].rank) / 2;
             OptionA.rank = newRank;
+            OptionA.history.push(OptionB.id);
             console.log("SUBSEQUENT ALL RANKED NON 0 INDEX");
           }
         }
         // ! B SELECTED
         else if (action.payload.option === "B") {
           //console.log(rankedMovies);
-          console.log("SUBSEQENT SUBSEQUENT ALL RANKED - B SELECTED");
+          console.log("RANKED VS RANKED: B SELECTED -->");
           const index = rankedMovies.findIndex(
             (movies) => movies.rank === OptionB.rank
           );
+          OptionA.active = "lost";
+          OptionA.history.push(OptionB.id);
           if (OptionA.history.includes(OptionB.id)) {
             console.log(console.log("EXIT THE LOOP WE GOT HIM"));
-            OptionA.history.push(OptionB.id);
             delete OptionA.active;
           }
           // LOSING TO TOP RANKED ITEM
@@ -134,13 +140,11 @@ const movielistSlice = createSlice({
           } else if (index === rankedMovies.length - 1) {
             delete OptionA.active;
             OptionA.rank = rankedMovies[index].rank * 2;
-            OptionA.history.push(OptionB.id);
           } else {
             const lostNewRank =
               (rankedMovies[index].rank + rankedMovies[index + 1].rank) / 2;
             OptionA.rank = lostNewRank;
-            OptionA.active = "lost";
-            OptionA.history.push(OptionB.id);
+
             console.log("Option B Selected - Incumbent");
           }
         } else {

--- a/src/features/movielist/MovieList.js
+++ b/src/features/movielist/MovieList.js
@@ -33,8 +33,6 @@ const MovieList = () => {
   const A = "A";
   const B = "B";
 
-  const [encounter, setEncounter] = useState(0);
-
   //filtering movies into unranked and ranked
   const unrankedMovies = movies.filter((movie) => movie.rank == 0);
   // console.log("unranked movies array:", unrankedMovies);
@@ -107,7 +105,8 @@ const MovieList = () => {
         const activeRankedMovieIndex = moviesSortedByRank.findIndex(
           (movies) => movies.rank === activeRankedMovie[0].rank
         );
-        console.log("active rank movie index: " + activeRankedMovieIndex);
+
+        //activeRankedMovie[0].history.includes()
 
         // ! winners bracket
         if (activeRankedMovie[0].active === "won") {
@@ -126,54 +125,43 @@ const MovieList = () => {
             nextRankedIncumbentIndex - 1,
             nextRankedIncumbentIndex
           );
-          console.log("newrankedmovelist: ");
-          console.log(newRankedMoviesList);
-          console.log("nextrankedIncumbent");
-          console.log(nextRankedIncumbent);
+          // console.log("newrankedmovelist: ");
+          // console.log(newRankedMoviesList);
+          // console.log("nextrankedIncumbent");
+          // console.log(nextRankedIncumbent);
 
-          // const rankedIncumbent = moviesSortedByRank.slice(
-          //   nextChallengerIndex,
-          //   nextChallengerIndex + 1
-          // );
           const updatedCombatants = activeRankedMovie.concat(
             nextRankedIncumbent
           );
-          // const combatants = unrankedCombatant.concat(rankedIncumbent);
-          {
-            return (
+          return (
+            <div>
               <div>
-                <div>
-                  {activeRankedMovie.map((movie) => (
-                    <Movie
-                      key={movie.id}
-                      movie={movie}
-                      id={movie.id}
-                      active={movie.active}
-                      option={A}
-                      combatants={updatedCombatants}
-                      rankedMovies={newRankedMoviesList}
-                    />
-                  ))}
-                </div>
-                <div>
-                  {nextRankedIncumbent.map((movie) => (
-                    <Movie
-                      key={movie.id}
-                      movie={movie}
-                      id={movie.id}
-                      option={B}
-                      combatants={updatedCombatants}
-                      rankedMovies={newRankedMoviesList}
-                    />
-                  ))}
-                </div>
+                {activeRankedMovie.map((movie) => (
+                  <Movie
+                    key={movie.id}
+                    movie={movie}
+                    id={movie.id}
+                    active={movie.active}
+                    option={A}
+                    combatants={updatedCombatants}
+                    rankedMovies={newRankedMoviesList}
+                  />
+                ))}
               </div>
-            );
-          }
-          // const newMovieIndex = console.log(
-          //   "active ranked movie: " +
-          //     JSON.stringify(activeRankedMovie[0].rank, undefined, 1)
-          // );
+              <div>
+                {nextRankedIncumbent.map((movie) => (
+                  <Movie
+                    key={movie.id}
+                    movie={movie}
+                    id={movie.id}
+                    option={B}
+                    combatants={updatedCombatants}
+                    rankedMovies={newRankedMoviesList}
+                  />
+                ))}
+              </div>
+            </div>
+          );
         }
         // ! losers bracket
         else if (activeRankedMovie[0].active === "lost") {
@@ -196,10 +184,6 @@ const MovieList = () => {
           console.log("nextrankedIncumbent");
           console.log(nextRankedIncumbent);
 
-          // const rankedIncumbent = moviesSortedByRank.slice(
-          //   nextChallengerIndex,
-          //   nextChallengerIndex + 1
-          // );
           const updatedCombatants = activeRankedMovie.concat(
             nextRankedIncumbent
           );


### PR DESCRIPTION
Merging into Development. Ended up not moving history to the component as the logic was all within the redux slice but misaligned.

Moved OptionA.history.push(OptionB.id) to the last else {} of each Ranked vs Ranked segment. Previously it being placed above caused instances in which the current challenger was kicked out of the ranking loop prior to its final position. 